### PR TITLE
feature: use previous context for prompt infill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "twinny",
-  "version": "0.1.6",
+  "version": "0.1.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "twinny",
-      "version": "0.1.6",
+      "version": "0.1.9",
       "license": "MIT",
       "dependencies": {
         "openai": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -101,6 +101,10 @@
         "twinny.topP": {
           "type": "number",
           "default": 0.95
+        },
+        "twinny.useContext": {
+          "type": "boolean",
+          "default": true
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "twinny",
   "displayName": "twinny",
   "description": "Locally hosted AI code completion plugin for vscode",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "icon": "assets/icon.png",
   "keywords": [
     "code-inference",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
           "type": "number",
           "default": 0.95
         },
-        "twinny.useContext": {
+        "twinny.usePreviousContext": {
           "type": "boolean",
           "default": true
         }

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -29,7 +29,7 @@ export class CompletionProvider implements InlineCompletionItemProvider {
   private _openaiConfig = new Configuration()
   private _serverPath = this._config.get('server')
   private _engine = this._config.get('engine')
-  private _useContext = this._config.get('useContext')
+  private _usePreviousContext = this._config.get('usePreviousContext')
   private _basePath = `${this._serverPath}/${this._engine}`
   private _openai: OpenAIApi = new OpenAIApi(this._openaiConfig, this._basePath)
 
@@ -102,7 +102,7 @@ export class CompletionProvider implements InlineCompletionItemProvider {
   private getPrompt(document: TextDocument, position: Position) {
     const { prefix, suffix } = this.getContext(document, position)
     const prompt = `
-      ${this._useContext ? `${this._lineContexts.join('\n')}\n` : ''}
+      ${this._usePreviousContext ? `${this._lineContexts.join('\n')}\n` : ''}
       ${prefix}<FILL_HERE>${suffix}
     `
     console.log(prompt)
@@ -112,7 +112,7 @@ export class CompletionProvider implements InlineCompletionItemProvider {
   private registerOnChangeContextListener() {
     let timeout: NodeJS.Timer | undefined
     window.onDidChangeTextEditorSelection((e) => {
-      if (!this._useContext) {
+      if (!this._usePreviousContext) {
         return
       }
       if (timeout) clearTimeout(timeout)
@@ -203,7 +203,7 @@ export class CompletionProvider implements InlineCompletionItemProvider {
     this._contextLength = this._config.get('contextLength') as number
     this._serverPath = this._config.get('server')
     this._engine = this._config.get('engine')
-    this._useContext = this._config.get('useContext')
+    this._usePreviousContext = this._config.get('_usePreviousContext')
 
     this._basePath = `${this._serverPath}/${this._engine}`
     this._openai = new OpenAIApi(this._openaiConfig, this._basePath)

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -105,7 +105,6 @@ export class CompletionProvider implements InlineCompletionItemProvider {
       ${this._usePreviousContext ? `${this._lineContexts.join('\n')}\n` : ''}
       ${prefix}<FILL_HERE>${suffix}
     `
-    console.log(prompt)
     return prompt
   }
 

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -189,7 +189,7 @@ export class CompletionProvider implements InlineCompletionItemProvider {
         }
 
         return new InlineCompletionItem(
-          choice.text?.trim() as string,
+          choice.text as string,
           new Range(position, position)
         )
       }) || []

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -105,8 +105,6 @@ export class CompletionProvider implements InlineCompletionItemProvider {
       \n
       ${prefix}<FILL_HERE>${suffix}
     `
-    console.debug(prompt)
-
     return prompt
   }
 


### PR DESCRIPTION
This PR adds previous context to the prompt to help the model deliver the infill based on previous cursor locations.  It also adds an option to enable or disable it.