### PR TITLE
handle large chunks that get split by http lib

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -22,11 +22,18 @@ export async function streamResponse(opts: StreamResponseOptions) {
 
   const _request = useTls ? httpsRequest : request
 
+  let ongoingChunk = ''
+
   const req = _request(options, (res) => {
     res.on('data', (chunk: string) => {
-      onData(chunk, () => {
-        res.destroy()
-      })
+      ongoingChunk += chunk
+      if (/\n$/.exec(chunk)) {
+        onData(ongoingChunk, () => {
+          res.destroy()
+        })
+
+        ongoingChunk = ''
+      }
     })
 
     res.once('end', () => {


### PR DESCRIPTION
Closes #44 by looking for HTTP chunk delimiters in the HTTP stream coming back from Ollama.

Here's an example of a stream captured with `tcpdump`:

```
HTTP/1.1 200 OK
Content-Type: application/x-ndjson
Date: Wed, 24 Jan 2024 17:14:00 GMT
Connection: close
Transfer-Encoding: chunked

69
{"model":"codellama:13b-code","created_at":"2024-01-24T17:14:00.708054246Z","response":"(","done":false}

6e
{"model":"codellama:13b-code","created_at":"2024-01-24T17:14:00.719238491Z","response":"module","done":false}

69
{"model":"codellama:13b-code","created_at":"2024-01-24T17:14:00.730212903Z","response":".","done":false}

```

The server is sending two newlines at the end of each chunk. This PR updates `streamResponse` to concatenate all the data it receives from the HTTP stream until it gets a piece of data ending with `\n`, then it send all the data (the whole HTTP chunk) to the caller.

Tested with HTTP chunks that did get split coming back from the server as well as normal chunks.