### PR TITLE
Use VSCode focus option to focus on twinny panel - 2 

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,17 +83,17 @@
       "view/title": [
         {
           "command": "twinny.templates",
-          "when": "view == twinny-sidebar",
+          "when": "view == twinny.sidebar",
           "group": "navigation@0"
         },
         {
           "command": "twinny.newChat",
-          "when": "view == twinny-sidebar",
+          "when": "view == twinny.sidebar",
           "group": "navigation@1"
         },
         {
           "command": "twinny.settings",
-          "when": "view == twinny-sidebar",
+          "when": "view == twinny.sidebar",
           "group": "navigation@2"
         }
       ]
@@ -164,7 +164,7 @@
       },
       {
         "key": "CTRL+SHIFT+t",
-        "command": "workbench.view.extension.twinny-sidebar-view"
+        "command": "twinny.sidebar.focus"
       },
       {
         "key": "CTRL+SHIFT+/",
@@ -184,7 +184,7 @@
       "twinny-sidebar-view": [
         {
           "type": "webview",
-          "id": "twinny-sidebar",
+          "id": "twinny.sidebar",
           "name": "twinny",
           "icon": "assets/twinny.svg",
           "contextualTitle": "twinny"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -59,13 +59,13 @@ export async function activate(context: ExtensionContext) {
       statusBar.hide()
     }),
     commands.registerCommand('twinny.explain', () => {
-      commands.executeCommand('workbench.view.extension.twinny-sidebar-view')
+      commands.executeCommand('twinny.sidebar.focus')
       delayExecution(() =>
         sidebarProvider.chatService?.streamTemplateCompletion('explain')
       )
     }),
     commands.registerCommand('twinny.fixCode', () => {
-      commands.executeCommand('workbench.view.extension.twinny-sidebar-view')
+      commands.executeCommand('twinny.sidebar.focus')
       delayExecution(() =>
         sidebarProvider.chatService?.streamTemplateCompletion('fix-code')
       )
@@ -75,25 +75,25 @@ export async function activate(context: ExtensionContext) {
       sidebarProvider.destroyStream()
     }),
     commands.registerCommand('twinny.addTypes', () => {
-      commands.executeCommand('workbench.view.extension.twinny-sidebar-view')
+      commands.executeCommand('twinny.sidebar.focus')
       delayExecution(() =>
         sidebarProvider.chatService?.streamTemplateCompletion('add-types')
       )
     }),
     commands.registerCommand('twinny.refactor', () => {
-      commands.executeCommand('workbench.view.extension.twinny-sidebar-view')
+      commands.executeCommand('twinny.sidebar.focus')
       delayExecution(() =>
         sidebarProvider.chatService?.streamTemplateCompletion('refactor')
       )
     }),
     commands.registerCommand('twinny.addTests', () => {
-      commands.executeCommand('workbench.view.extension.twinny-sidebar-view')
+      commands.executeCommand('twinny.sidebar.focus')
       delayExecution(() =>
         sidebarProvider.chatService?.streamTemplateCompletion('add-tests')
       )
     }),
     commands.registerCommand('twinny.generateDocs', () => {
-      commands.executeCommand('workbench.view.extension.twinny-sidebar-view')
+      commands.executeCommand('twinny.sidebar.focus')
       delayExecution(() =>
         sidebarProvider.chatService?.streamTemplateCompletion('generate-docs')
       )
@@ -116,7 +116,7 @@ export async function activate(context: ExtensionContext) {
         key: MESSAGE_KEY.lastConversation
       })
     }),
-    window.registerWebviewViewProvider('twinny-sidebar', sidebarProvider),
+    window.registerWebviewViewProvider('twinny.sidebar', sidebarProvider),
     statusBar
   )
 


### PR DESCRIPTION
See PR https://github.com/rjmacarthy/twinny/pull/64

Currently, the focus on the Twinny panel does not work well.
Example:

![without-fix](https://github.com/rjmacarthy/twinny/assets/6225039/0c45ec75-70fd-4a84-bc61-f071354aec95)

This PR aims to use the VSCode native command to focus on a view to make it works.
Here's the result after the fix I propose

![with-fix](https://github.com/rjmacarthy/twinny/assets/6225039/37740c18-47e3-4874-8f60-8cb3d158dc52)

You'll notice that in the first case, a sidepanel is open but it is not the one of twinny