### PR TITLE
Fixing the duplicate text when opening new document

### DIFF
--- a/src/providers/sidebar.ts
+++ b/src/providers/sidebar.ts
@@ -138,7 +138,6 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
       language: lang.languageId
     })
     await vscode.window.showTextDocument(document)
-    const editor = await vscode.window.showTextDocument(document)
   }
 
   public getGlobalContext = (data: ClientMessage) => {

--- a/src/providers/sidebar.ts
+++ b/src/providers/sidebar.ts
@@ -139,11 +139,6 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
     })
     await vscode.window.showTextDocument(document)
     const editor = await vscode.window.showTextDocument(document)
-
-    await editor.edit((editBuilder) => {
-      const startPosition = new vscode.Position(0, 0)
-      editBuilder.insert(startPosition, data.data as string)
-    })
   }
 
   public getGlobalContext = (data: ClientMessage) => {


### PR DESCRIPTION
To address this issue:

https://github.com/rjmacarthy/twinny/issues/103

We are providing the content of the document already in the `openTextDocument` call, no need to extra insert it later