### PR TITLE
Selection button icons change depending on the state

### DIFF
--- a/src/webview/chat.tsx
+++ b/src/webview/chat.tsx
@@ -20,6 +20,8 @@ import {
 import {
   DisabledAutoScrollIcon,
   EnabledAutoScrollIcon,
+  DisabledSelectionIcon,
+  EnabledSelectionIcon
 } from './icons'
 
 import { Suggestions } from './suggestions'
@@ -259,7 +261,11 @@ export const Chat = () => {
             appearance="icon"
             onClick={handleToggleSelection}
           >
-            <span className="codicon codicon-code"></span>
+            {isSelectionVisible ? (
+              <EnabledSelectionIcon />
+            ) : (
+              <DisabledSelectionIcon />
+            )}
           </VSCodeButton>
           <VSCodeBadge>Selected characters: {selection?.length}</VSCodeBadge>
         </div>

--- a/src/webview/icons.tsx
+++ b/src/webview/icons.tsx
@@ -59,3 +59,69 @@ export const DisabledAutoScrollIcon = () => (
     />
   </svg>
 )
+
+export const EnabledSelectionIcon = () => (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M 10 7 l -4 5 l 4 5"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+    <path
+      d="M 14 7 l 4 5 l -4 5"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M 13 6 l -2 12"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />    
+  </svg>
+)
+
+export const DisabledSelectionIcon = () => (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M 10 7 l -4 5 l 4 5"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+    <path
+      d="M 14 7 l 4 5 l -4 5"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M 13 6 l -2 12"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />    
+    <path
+      d="M 6 6 l 12 12"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+  </svg>
+)

--- a/src/webview/icons.tsx
+++ b/src/webview/icons.tsx
@@ -81,12 +81,6 @@ export const EnabledSelectionIcon = () => (
       strokeLinecap="round"
       strokeLinejoin="round"
     />
-    <path
-      d="M 13 6 l -2 12"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-    />    
   </svg>
 )
 
@@ -111,12 +105,6 @@ export const DisabledSelectionIcon = () => (
       strokeLinecap="round"
       strokeLinejoin="round"
     />
-    <path
-      d="M 13 6 l -2 12"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-    />    
     <path
       d="M 6 6 l 12 12"
       stroke="currentColor"


### PR DESCRIPTION
To address the issue: https://github.com/rjmacarthy/twinny/issues/108

Couldn't use the vscode buttons (as there is no striked thorugh version of the button).
So I recreated it in the SVG so then the disabled button is the same just one extra strike through line.