### PR TITLE
Adds keep_alive with config for Ollama

### DIFF
--- a/package.json
+++ b/package.json
@@ -244,75 +244,81 @@
           "default": "ollama",
           "description": "The API provider to use (sets the paths and port automatically to defaults)."
         },
-        "twinny.chatApiPath": {
+        "twinny.keepModelsInMemory": {
           "order": 3,
+          "type": "boolean",
+          "default": false,
+          "description": "Keep models in memory by making requests with keep_alive=-1. Applicable only for Ollama API."
+        },
+        "twinny.chatApiPath": {
+          "order": 4,
           "type": "string",
           "default": "/api/generate",
           "description": "Endpoint path for chat completions. Defaults to '/api/generate' for Ollama and '/completion' for llama.cpp.",
           "required": true
         },
         "twinny.chatApiPort": {
-          "order": 4,
-          "type": "number",
-          "default": 11434,
-          "description": "The API port usually `11434` for Ollama and `8080` for llama.cpp (May differ depending on API configuration)",
-          "required": true
-        },
-        "twinny.fimApiPort": {
           "order": 5,
           "type": "number",
           "default": 11434,
           "description": "The API port usually `11434` for Ollama and `8080` for llama.cpp (May differ depending on API configuration)",
           "required": true
         },
-        "twinny.fimApiPath": {
+        "twinny.fimApiPort": {
           "order": 6,
+          "type": "number",
+          "default": 11434,
+          "description": "The API port usually `11434` for Ollama and `8080` for llama.cpp (May differ depending on API configuration)",
+          "required": true
+        },
+        "twinny.fimApiPath": {
+          "order": 7,
           "type": "string",
           "default": "/api/generate",
           "description": "Endpoint path for FIM completions. Defaults to '/api/generate' for Ollama and '/completion' for llama.cpp.",
           "required": true
         },
         "twinny.chatModelName": {
-          "order": 7,
+          "order": 8,
           "type": "string",
           "default": "codellama:7b-instruct",
           "description": "Model identifier for chat completions. Applicable only for Ollama and Oobabooga API."
         },
         "twinny.fimModelName": {
-          "order": 8,
+          "order": 9,
           "type": "string",
           "default": "codellama:7b-code",
           "description": "Model identifier for FIM completions. Applicable only for Ollama and Oobabooga API."
         },
         "twinny.disableAutoSuggest": {
-          "order": 10,
+          "order": 11,
           "type": "boolean",
           "default": false,
           "description": "Disables automatic suggestions, manual trigger (default shortcut Alt+\\)."
         },
         "twinny.contextLength": {
-          "order": 11,
+          "order": 12,
           "type": "number",
           "default": 30,
           "description": "Defines the number of lines before and after the current line to include in FIM prompts.",
           "required": true
         },
         "twinny.debounceWait": {
-          "order": 12,
+          "order": 13,
           "type": "number",
           "default": 300,
           "description": "Delay in milliseconds before triggering the next completion.",
           "required": true
         },
         "twinny.temperature": {
-          "order": 13,
+          "order": 14,
           "type": "number",
           "default": 0.2,
           "description": "Sets the model's creativity level (temperature) for generating completions.",
           "required": true
         },
         "twinny.useMultiLineCompletions": {
-          "order": 14,
+          "order": 15,
           "type": "boolean",
           "default": false,
           "description": "Use multiline completions, can be inaccurate in some cases."
@@ -321,57 +327,57 @@
           "dependencies": {
             "twinny.useMultiLineCompletions": true
           },
-          "order": 15,
+          "order": 16,
           "type": "number",
           "default": 20,
           "description": "Maximum number of lines to use for multi line completions. Applicable only when useMultiLineCompletions is enabled."
         },
         "twinny.useFileContext": {
-          "order": 16,
+          "order": 17,
           "type": "boolean",
           "default": false,
           "description": "Enables scanning of neighbouring documents to enhance completion prompts. (Experimental)"
         },
         "twinny.enableCompletionCache": {
-          "order": 17,
+          "order": 18,
           "type": "boolean",
           "default": false,
           "description": "Caches FIM completions for identical prompts to enhance performance."
         },
         "twinny.numPredictChat": {
-          "order": 18,
+          "order": 19,
           "type": "number",
           "default": 512,
           "description": "Maximum token limit for chat completions.",
           "required": true
         },
         "twinny.numPredictFim": {
-          "order": 19,
+          "order": 20,
           "type": "number",
           "default": -1,
           "description": "Maximum token limit for FIM completions. Set to -1 for no limit. Twinny stops at logical line breaks.",
           "required": true
         },
         "twinny.disableServerChecks": {
-          "order": 20,
+          "order": 21,
           "type": "boolean",
           "default": false,
           "description": "Disables automatic LLM server checks at startup, preventing auto-downloads and prompts."
         },
         "twinny.useTls": {
-          "order": 21,
+          "order": 22,
           "type": "boolean",
           "default": false,
           "description": "Enables TLS encryption for API connections."
         },
         "twinny.apiBearerToken": {
-          "order": 22,
+          "order": 23,
           "type": "string",
           "default": "",
           "description": "Bearer token for secure API authentication."
         },
         "twinny.enableLogging": {
-          "order": 23,
+          "order": 24,
           "type": "boolean",
           "default": false,
           "description": "Enable twinny debug mode"

--- a/src/extension/model-options.ts
+++ b/src/extension/model-options.ts
@@ -1,3 +1,4 @@
+import { workspace } from 'vscode'
 import {
   MessageRoleContent,
   ApiProviders,
@@ -16,10 +17,12 @@ export function createStreamRequestBody(
     messages?: MessageRoleContent[]
   }
 ): StreamBodyBase | StreamOptionsOllama | StreamBodyOpenAI {
+  const config = workspace.getConfiguration('twinny')
+
   switch (provider) {
     case ApiProviders.Ollama:
     case ApiProviders.OllamaWebUi:
-      return {
+      var result: StreamOptionsOllama = {
         model: options.model,
         prompt,
         stream: true,
@@ -28,6 +31,10 @@ export function createStreamRequestBody(
           num_predict: options.numPredictChat
         }
       }
+      if (config.get('keepModelsInMemory')) {
+        result.keep_alive = -1
+      }
+      return result
     case ApiProviders.LlamaCpp:
       return {
         prompt,

--- a/src/extension/types.ts
+++ b/src/extension/types.ts
@@ -11,6 +11,7 @@ export interface StreamBodyBase {
 
 export interface StreamOptionsOllama extends StreamBodyBase {
   model: string
+  keep_alive?: number
   options: Record<string, unknown>
 }
 


### PR DESCRIPTION
Ollama supports keep_alive now and it's annoying when large models get evicted while using twinny, let's remedy that. I have never written TypeScript before, so this works but it might not be clean.

This depends on my recently merged PR in Ollama to fix a bug with negative keep_alive. See [here](https://github.com/ollama/ollama/pull/2480).