### PR TITLE
deletes language property from body request

### DIFF
--- a/src/extension/stream.ts
+++ b/src/extension/stream.ts
@@ -1,8 +1,32 @@
-import { StreamRequest } from '../common/types'
+import { MessageRoleContent, MessageType, StreamRequest, StreamBodyOpenAI } from '../common/types'
 import { logStreamOptions, safeParseJsonResponse } from './utils'
 import { COMPLETION_TIMEOUT } from '../common/constants'
 
+
+
+
+function deleteLanguageFromMessages(messages: MessageType[] | MessageRoleContent | undefined)
+{
+  // check if messages is MessageType[] -- role does not have a language property
+  if (Array.isArray(messages)) {
+    messages.forEach(element => {
+      delete element.language;  
+    });
+  }
+
+}
+
 export async function streamResponse(request: StreamRequest) {
+
+  // check if request.body is of type StreamBodyOpenAI
+  if ((request.body as StreamBodyOpenAI).messages){
+    // delete language from request body as is not really part of the OpenAI specification 
+    deleteLanguageFromMessages((request.body as StreamBodyOpenAI).messages)
+  }
+
+
+
+
   logStreamOptions(request)
   const { body, options, onData, onEnd, onError, onStart } = request
   const controller = new AbortController()


### PR DESCRIPTION
A stated in #150, sending a `language` key in the request of the endpoint `chat/completions` is not part of the OpenAI API. This causes problems with some providers, such as VLLM (whose API is fully OpenAI compliant).

This PR resolves the issue by deleting the `language` key in the messages of the body request.