### PR TITLE
Add starcoder2 (and dolphincoder) support to autocomplete (not complete yet)

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -85,7 +85,8 @@ export const FIM_TEMPLATE_FORMAT = {
   deepseek: 'deepseek',
   llama: 'llama',
   stableCode: 'stable-code',
-  starcoder: 'starcoder'
+  starcoder: 'starcoder',
+  starcoder2: 'starcoder2'
 }
 
 export const STOP_LLAMA = ['<EOT>']
@@ -96,6 +97,14 @@ export const STOP_DEEPSEEK = [
   '<｜fim▁end｜>',
   '<END>',
   '<｜end▁of▁sentence｜>'
+]
+
+export const STOP_STARCODER2 = [
+  "<fim_prefix>",
+  "<fim_suffix>",
+  "<fim_middle>",
+  "<|endoftext|>",
+  "<file_sep>"
 ]
 
 export const STOP_STABLECODE = ['<|endoftext|>']

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,5 +1,5 @@
-import { InlineCompletionItem, InlineCompletionList } from 'vscode'
-import { CodeLanguageDetails } from './languages'
+import { InlineCompletionItem, InlineCompletionList, Range, Uri } from 'vscode'
+import { CodeLanguage, CodeLanguageDetails } from './languages'
 import { ALL_BRACKETS } from './constants'
 
 export interface StreamBodyBase {
@@ -13,6 +13,7 @@ export interface StreamOptionsOllama extends StreamBodyBase {
   keep_alive?: string | number
   messages?: MessageType[] | MessageRoleContent
   prompt: string
+  raw?: boolean
   options: Record<string, unknown>
 }
 
@@ -106,9 +107,26 @@ export interface ChatTemplateData {
 
 export type ThemeType = (typeof Theme)[keyof typeof Theme]
 
+export interface FimFileMetadata {
+  readonly lang_id: CodeLanguage
+  readonly lang: CodeLanguageDetails
+  readonly uri: Uri
+
+  toString() : string
+}
+
+export interface FimFileSnippet extends FimFileMetadata {
+  readonly range: Range,
+  readonly content: string
+}
+
+export interface FimFileContext extends Array<FimFileMetadata> {
+  toString() : string
+}
+
 export interface FimPromptTemplate {
+  file?: FimFileMetadata
   context: string
-  header: string
   prefixSuffix: PrefixSuffix
   useFileContext: boolean
   language?: string

--- a/src/extension/fim-templates.ts
+++ b/src/extension/fim-templates.ts
@@ -2,14 +2,15 @@ import {
   FIM_TEMPLATE_FORMAT,
   STOP_DEEPSEEK,
   STOP_LLAMA,
+  STOP_STARCODER2,
   STOP_STABLECODE
 } from '../common/constants'
 import { supportedLanguages } from '../common/languages'
 import { FimPromptTemplate } from '../common/types'
 
 export const getFimPromptTemplateLLama = ({
+  file,
   context,
-  header,
   useFileContext,
   prefixSuffix,
   language
@@ -22,14 +23,14 @@ export const getFimPromptTemplateLLama = ({
         languageId?.syntaxComments?.end || ''
       }`
     : ''
-  const heading = header ? header : ''
+  const heading = file ? file.toString() : ''
 
   return `<PRE>${fileContext} \n${heading}${prefix} <SUF> ${suffix} <MID>`
 }
 
 export const getDefaultFimPromptTemplate = ({
+  file,
   context,
-  header,
   useFileContext,
   prefixSuffix,
   language
@@ -40,13 +41,13 @@ export const getDefaultFimPromptTemplate = ({
   const fileContext = useFileContext
     ? `${languageId?.syntaxComments?.start}${context}${languageId?.syntaxComments?.end}`
     : ''
-  const heading = header ? header : ''
+  const heading = file ? file.toString() : ''
   return `<PRE> ${fileContext}\n${heading}${prefix} <SUF> ${suffix} <MID>`
 }
 
 export const getFimPromptTemplateDeepseek = ({
+  file,
   context,
-  header,
   useFileContext,
   prefixSuffix,
   language
@@ -57,19 +58,36 @@ export const getFimPromptTemplateDeepseek = ({
   const fileContext = useFileContext
     ? `${languageId?.syntaxComments?.start}${context}${languageId?.syntaxComments?.end}`
     : ''
-  const heading = header ? header : ''
+  const heading = file ? file.toString() : ''
   return `<｜fim▁begin｜>${fileContext}\n${heading}${prefix}<｜fim▁hole｜>${suffix}<｜fim▁end｜>`
 }
 
-export const getFimPromptTemplateStableCode = ({
+export const getFimPromptTemplateStarcoder2 = ({
+  file,
   context,
-  header,
   useFileContext,
   prefixSuffix
 }: FimPromptTemplate) => {
   const { prefix, suffix } = prefixSuffix
   const fileContext = useFileContext ? context : ''
-  const heading = header ? header : ''
+
+  if (file) {
+    return `<file_sep>${file.uri.toString()}\n<fim_prefix>${prefix}<fim_suffix>${suffix}<fim_middle>`
+  }
+  else {
+    return `<fim_prefix>${prefix}<fim_suffix>${suffix}<fim_middle>`
+  }
+}
+
+export const getFimPromptTemplateStableCode = ({
+  file,
+  context,
+  useFileContext,
+  prefixSuffix
+}: FimPromptTemplate) => {
+  const { prefix, suffix } = prefixSuffix
+  const fileContext = useFileContext ? context : ''
+  const heading = file ? file.toString() : ''
   return `<fim_prefix>${fileContext}\n${heading}${prefix}<fim_suffix>${suffix}<fim_middle>`
 }
 
@@ -83,6 +101,10 @@ function getFimTemplateAuto(fimModel: string, args: FimPromptTemplate) {
 
   if (fimModel.includes(FIM_TEMPLATE_FORMAT.deepseek)) {
     return getFimPromptTemplateDeepseek(args)
+  }
+
+  if (fimModel.includes(FIM_TEMPLATE_FORMAT.starcoder2)) {
+    return getFimPromptTemplateStarcoder2(args)
   }
 
   if (
@@ -102,6 +124,10 @@ function getFimTemplateChosen(format: string, args: FimPromptTemplate) {
 
   if (format === FIM_TEMPLATE_FORMAT.deepseek) {
     return getFimPromptTemplateDeepseek(args)
+  }
+
+  if (format === FIM_TEMPLATE_FORMAT.starcoder2) {
+    return getFimPromptTemplateStarcoder2(args)
   }
 
   if (format === FIM_TEMPLATE_FORMAT.stableCode || format === FIM_TEMPLATE_FORMAT.starcoder) {
@@ -134,6 +160,10 @@ export const getStopWordsAuto = (fimModel: string) => {
     return STOP_DEEPSEEK
   }
 
+  if (fimModel.includes(FIM_TEMPLATE_FORMAT.starcoder2)) {
+    return STOP_STARCODER2
+  }
+
   if (
     fimModel.includes(FIM_TEMPLATE_FORMAT.stableCode) ||
     fimModel.includes(FIM_TEMPLATE_FORMAT.starcoder)
@@ -147,6 +177,7 @@ export const getStopWordsAuto = (fimModel: string) => {
 export const getStopWordsChosen = (format: string) => {
   if (format === FIM_TEMPLATE_FORMAT.codellama) return STOP_LLAMA
   if (format === FIM_TEMPLATE_FORMAT.deepseek) return STOP_DEEPSEEK
+  if (format === FIM_TEMPLATE_FORMAT.starcoder2) return STOP_STARCODER2
   if (format === FIM_TEMPLATE_FORMAT.stableCode || format === FIM_TEMPLATE_FORMAT.starcoder) return STOP_STABLECODE
   return STOP_LLAMA
 }

--- a/src/extension/model-options.ts
+++ b/src/extension/model-options.ts
@@ -15,6 +15,7 @@ export function createStreamRequestBody(
     model: string
     messages?: MessageRoleContent[]
     keepAlive?: string | number
+    raw?: boolean
   }
 ): StreamBodyBase | StreamOptionsOllama | StreamBodyOpenAI {
   switch (provider) {
@@ -24,6 +25,7 @@ export function createStreamRequestBody(
         model: options.model,
         prompt,
         stream: true,
+        raw: options.raw,
         messages: options.messages,
         keep_alive: options.keepAlive,
         options: {


### PR DESCRIPTION
This needed two changes:

- Starcoder2 requires raw mode for ollama. The model template that ollama wraps around the prompt otherwise means FIM is not detected by the model
- The file details passed to the autocomplete template needed to be structured, as starcoder2 needs them in a different format to what the fixed string encoding was (see https://arxiv.org/pdf/2402.19173.pdf for format details)

To do before this could be merged:

- Change the file context to also be a structured object, rather than just a string. That needs changes to file-interaction cache.
- Probably broke tests

And some other ideas to improve results generally:

- Add language-specific stop words (which is how continue stops very long multi-line autocompletes)
- A different idea would be to look at the depth in the tree hierarchy and stop if the autocomplete goes up a level (so if you're inside an `if` block, stop once the block has been completed at most)

BTW, I think there's a bug in the file-interaction code - `onDidOpenTextDocument` doesn't track focus or which window is active, multiple files can be "open" in different windows at the same time. I think it should be rewritten to use `onDidChangeActiveTextEditor` instead?

Raising for now to start discussion.