### PR TITLE
Update README.md for correct model pull

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ Through the side bar, have a conversation with your model and get explanations a
 3. Choose your model from the [library](https://ollama.com/library) (eg: `codellama:7b`)
 
 ```sh
-ollama run codellama:7b
+ollama run codellama:7b-instruct
+ollama run codellama:7b-code
 ```
 
 4. Open VS code (if already open a restart might be needed) and press `ctr + shift + T` to open the side panel.


### PR DESCRIPTION
When I was setting up twinny today I followed the instructions here but the requests to the server would end up in 404. This was because as per docs the codelama:7b model itself was pulled but not the instruct or code variants. The ollama OpenAI API will 404 and return {"error":"model 'XXX' not found, try pulling it first"}.