### PR TITLE
Adds CodeGemma for FIM Completion

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -91,6 +91,7 @@ export const FIM_TEMPLATE_FORMAT = {
   llama: 'llama',
   stableCode: 'stable-code',
   starcoder: 'starcoder',
+  codegemma: 'codegemma',
   custom: 'custom-template'
 }
 
@@ -105,6 +106,8 @@ export const STOP_DEEPSEEK = [
 ]
 
 export const STOP_STARCODER = ['<|endoftext|>']
+
+export const STOP_CODEGEMMA = ['<|file_separator|>', '<|end_of_turn|>', '<eos>']
 
 export const DEFAULT_TEMPLATE_NAMES = defaultTemplates.map(({ name }) => name)
 

--- a/src/extension/fim-templates.ts
+++ b/src/extension/fim-templates.ts
@@ -2,7 +2,8 @@ import {
   FIM_TEMPLATE_FORMAT,
   STOP_DEEPSEEK,
   STOP_LLAMA,
-  STOP_STARCODER
+  STOP_STARCODER,
+  STOP_CODEGEMMA,
 } from '../common/constants'
 import { supportedLanguages } from '../common/languages'
 import { FimPromptTemplate } from '../common/types'
@@ -72,6 +73,23 @@ export const getFimPromptTemplateStableCode = ({
   return `<fim_prefix>${fileContext}\n${heading}${prefix}<fim_suffix>${suffix}<fim_middle>`
 }
 
+export const getFimPromptTemplateCodegemma = ({
+  context,
+  header,
+  useFileContext,
+  prefixSuffix,
+  language
+}: FimPromptTemplate) => {
+  const { prefix, suffix } = prefixSuffix
+  const languageId =
+    supportedLanguages[language as keyof typeof supportedLanguages]
+  const fileContext = useFileContext
+    ? `${languageId?.syntaxComments?.start}${context}${languageId?.syntaxComments?.end}`
+    : ''
+  const heading = header ? header : ''
+  return `<|fim_prefix|>${prefix}<|fim_suffix|>${suffix}<|fim_middle|>`
+}
+
 function getFimTemplateAuto(fimModel: string, args: FimPromptTemplate) {
   if (
     fimModel.includes(FIM_TEMPLATE_FORMAT.codellama) ||
@@ -91,6 +109,10 @@ function getFimTemplateAuto(fimModel: string, args: FimPromptTemplate) {
     return getFimPromptTemplateStableCode(args)
   }
 
+  if (fimModel.includes(FIM_TEMPLATE_FORMAT.codegemma)) {
+    return getFimPromptTemplateCodegemma(args)
+  }
+
   return getDefaultFimPromptTemplate(args)
 }
 
@@ -108,6 +130,10 @@ function getFimTemplateChosen(format: string, args: FimPromptTemplate) {
     format === FIM_TEMPLATE_FORMAT.starcoder
   ) {
     return getFimPromptTemplateStableCode(args)
+  }
+
+  if (format === FIM_TEMPLATE_FORMAT.codegemma) {
+    return getFimPromptTemplateCodegemma(args)
   }
 
   return getDefaultFimPromptTemplate(args)
@@ -143,6 +169,10 @@ export const getStopWordsAuto = (fimModel: string) => {
     return ['<|endoftext|>']
   }
 
+  if (fimModel.includes(FIM_TEMPLATE_FORMAT.codegemma)) {
+    return STOP_CODEGEMMA
+  }
+
   return STOP_LLAMA
 }
 
@@ -154,6 +184,7 @@ export const getStopWordsChosen = (format: string) => {
     format === FIM_TEMPLATE_FORMAT.starcoder
   )
     return STOP_STARCODER
+  if (format === FIM_TEMPLATE_FORMAT.codegemma) return STOP_CODEGEMMA
   return STOP_LLAMA
 }
 


### PR DESCRIPTION
This PR adds FIM sentinels, stop words and other config to use CodeGemma 2B PT and Codegemma 7B PT for inline code completion. PR tested working with default server settings in LM Studio 0.2.13 (latest as of writing).

Download models:
- CodeGemma 2B PT: https://huggingface.co/google/codegemma-2b
- CodeGemma 7B PT: https://huggingface.co/google/codegemma-7b

Recommended Usage:
- LM Studio (recommended), Ollama
- repeat penalty = 1.0 is optimal for this model